### PR TITLE
Named main components

### DIFF
--- a/src/components/Data/Browse/Treeview.vue
+++ b/src/components/Data/Browse/Treeview.vue
@@ -32,6 +32,7 @@
   import Vue from 'vue'
 
   export default {
+    name: 'Treeview',
     props: ['tree'],
     data () {
       return {

--- a/src/components/Data/Collection.vue
+++ b/src/components/Data/Collection.vue
@@ -14,3 +14,9 @@
     </div>
   </section>
 </template>
+
+<script>
+  export default {
+    name: 'CollectionSummary'
+  }
+</script>

--- a/src/components/Data/Layout.vue
+++ b/src/components/Data/Layout.vue
@@ -34,6 +34,7 @@
   import Treeview from './Browse/Treeview'
 
   export default {
+    name: 'DataLayout',
     components: {
       Treeview
     },

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -9,6 +9,7 @@
 <script>
   import MainMenu from './Materialize/MainMenu'
   export default {
+    name: 'Home',
     components: {
       MainMenu
     }

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -46,6 +46,7 @@
   import {getError} from '../vuex/modules/common/getters'
 
   export default {
+    name: 'Login',
     data () {
       return {
         username: null,

--- a/src/components/Security/Layout.vue
+++ b/src/components/Security/Layout.vue
@@ -21,3 +21,9 @@
   </section>
 
 </template>
+
+<script>
+  export default {
+    name: 'SecurityLayout'
+  }
+</script>

--- a/src/components/Security/Profiles/List.vue
+++ b/src/components/Security/Profiles/List.vue
@@ -1,3 +1,9 @@
 <template>
   <h1>Profiles management</h1>
 </template>
+
+<script>
+  export default {
+    name: 'ProfilesList'
+  }
+</script>

--- a/src/components/Security/Roles/List.vue
+++ b/src/components/Security/Roles/List.vue
@@ -1,3 +1,9 @@
 <template>
   <h1>Roles management</h1>
 </template>
+
+<script>
+  export default {
+    name: 'RolesList'
+  }
+</script>

--- a/src/components/Security/Users/List.vue
+++ b/src/components/Security/Users/List.vue
@@ -70,6 +70,7 @@
   import {documents, totalDocuments, selectedDocuments} from '../../../vuex/modules/collection/getters'
 
   export default {
+    name: 'UsersList',
     components: {
       Headline,
       Pagination,


### PR DESCRIPTION
The main components now have a name, so that we have no more "AnonymousComponent" in the Vue Chrome Extension. [Dad says it in this thread]( http://forum.vuejs.org/topic/792/vue-router-components-show-as-anonymous-component-how-do-i-name-them/2).

In the future, we should try to be consistent with the convention of explicitly setting a `name` property to all our components.