### PR TITLE
Add toaster directive

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,17 +1,20 @@
 <template>
+  <div class="toast-error" v-toaster></div>
   <router-view></router-view>
 </template>
 
 <script>
 import {} from './assets/global.scss'
+import Toaster from './directives/toaster.directive'
 
 window.jQuery = window.$ = require('jquery')
-require('imports?$=jquery!materialize-css/dist/js/materialize')
+require('materialize-css/dist/js/materialize')
 
 import 'font-awesome/css/font-awesome.css'
 
 export default {
-  replace: false
+  replace: false,
+  directives: [Toaster]
 }
 </script>
 

--- a/src/assets/layout.scss
+++ b/src/assets/layout.scss
@@ -45,6 +45,15 @@ main {
   }
 }
 
+#toast-container {
+  .toast {
+    &.error {
+      color: #fff;
+      background-color: $error-color;
+    }
+  }
+}
+
 .side-nav {
   top: $navbar-height;
   overflow: hidden;

--- a/src/directives/toaster.directive.js
+++ b/src/directives/toaster.directive.js
@@ -1,0 +1,9 @@
+export default {
+  id: 'toaster',
+  bind () {
+    /* eslint no-undef: 0 */
+    this.vm.$on('toast', (text, cssClass = '', duration = 5000, cb) => {
+      Materialize.toast(text, duration, cssClass, cb)
+    })
+  }
+}


### PR DESCRIPTION
This directive can't be test because of global variable `Materialize`.

**How to use**
In any component, use `this.$dispatch('toast', text/html, cssClass, duration, cb)`
* text/html is the only required parameter 
* cb is executed when the toast is closed
* "error" is the only current available cssClass
