### PR TITLE
Small refactor: remove $route refs

### DIFF
--- a/docker-compose/run-dev.sh
+++ b/docker-compose/run-dev.sh
@@ -2,7 +2,7 @@
 
 echo "Installing dependencies..."
 npm install
-bower install
+bower install --allow-root
 
 echo "Starting dev server..."
 npm run dev

--- a/docker-compose/run-test.sh
+++ b/docker-compose/run-test.sh
@@ -4,7 +4,7 @@ kuzzle=${KUZZLE_HOST:-kuzzle:7511}
 
 echo "Installing dependencies..."
 npm install
-bower install
+bower install --allow-root
 
 echo "Starting Tests..."
 

--- a/src/components/Data/Browse/IndexBranch.vue
+++ b/src/components/Data/Browse/IndexBranch.vue
@@ -1,24 +1,24 @@
 <template>
   <div :class="{ 'open': open }">
-    <i v-if="collectionCount(index)" class="fa fa-caret-right tree-toggle" aria-hidden="true" @click="toggleBranch()"></i>
-    <a v-link="{name: 'DataIndexSummary', params: {index: index.name}}" class="tree-item truncate"
-       :class="{ 'active': isIndexActive($route, index.name) }">
+    <i v-if="collectionCount(indexTree)" class="fa fa-caret-right tree-toggle" aria-hidden="true" @click="toggleBranch()"></i>
+    <a v-link="{name: 'DataIndexSummary', params: {index: indexTree.name}}" class="tree-item truncate"
+       :class="{ 'active': isIndexActive(indexTree.name) }">
       <i class="fa fa-database" aria-hidden="true"></i>
-      <strong>{{index.name}}</strong> ({{collectionCount(index)}})
+      <strong>{{indexTree.name}}</strong> ({{collectionCount(indexTree)}})
     </a>
     <ul class="collections">
-      <li v-for="collection in index.collections.stored | orderBy 1">
+      <li v-for="collectionTree in indexTree.collections.stored | orderBy 1">
         <a class="tree-item truncate"
-           v-link="{name: 'DataCollectionBrowse', params: {index: index.name, collection: collection}}"
-           :class="{ 'active': isCollectionActive($route, collection) }">
+           v-link="{name: 'DataCollectionBrowse', params: {index: indexTree.name, collection: collectionTree}}"
+           :class="{ 'active': isCollectionActive(collectionTree) }">
            <i class="fa fa-th-list" aria-hidden="true" title="Persisted collection"></i>
-           {{collection}}
+           {{collectionTree}}
          </a>
       </li>
-      <li v-for="collection in index.collections.realtime | orderBy 1">
+      <li v-for="collectionTree in indexTree.collections.realtime | orderBy 1">
         <a class="tree-item truncate">
           <i class="fa fa-bolt" aria-hidden="true" title="Volatile collection"></i>
-          {{collection}}
+          {{collectionTree}}
         </a>
       </li>
     </ul>
@@ -27,13 +27,18 @@
 
 <script>
 export default {
-  props: ['index'],
+  props: {
+    index: String,
+    collection: String,
+    indexTree: Object
+  },
   data: function () {
     return {
       open: false
     }
   },
   methods: {
+
     toggleBranch () {
       // TODO This state should be one day persistent across page refreshes
       this.open = !this.open
@@ -55,22 +60,25 @@ export default {
 
       return count
     },
-    isIndexActive (routeObject, indexName) {
-      return routeObject &&
-             routeObject.params &&
-             routeObject.params.index === indexName &&
-             !routeObject.params.collection
+    isTreeOpen (currentIndex, indexName) {
+      if (currentIndex === indexName) {
+        this.open = true
+      }
     },
-    isCollectionActive (routeObject, collectionName) {
-      return routeObject &&
-             routeObject.params &&
-             routeObject.params.collection === collectionName
+    isIndexActive (indexName) {
+      return this.index === indexName && !this.collection
+    },
+    isCollectionActive (collectionName) {
+      return this.collection === collectionName
+    }
+  },
+  watch: {
+    index: function (index) {
+      this.isTreeOpen(index, this.indexTree.name)
     }
   },
   ready: function () {
-    if (this.$route.params && this.$route.params.index === this.index.name) {
-      this.open = true
-    }
+    this.isTreeOpen(this.index, this.indexTree.name)
   }
 }
 </script>

--- a/src/components/Data/Browse/Treeview.vue
+++ b/src/components/Data/Browse/Treeview.vue
@@ -1,7 +1,7 @@
 <template>
   <ul class="indexes">
-    <li v-for="(key, index) in tree | orderBy 'name'">
-      <index-branch :index="index"></index-branch>
+    <li v-for="(key, indexTree) in tree | orderBy 'name'">
+      <index-branch :index-tree="indexTree" :index="index" :collection="collection"></index-branch>
     </li>
   </ul>
 </template>
@@ -11,7 +11,11 @@
 
   export default {
     name: 'Treeview',
-    props: ['tree'],
+    props: {
+      index: String,
+      collection: String,
+      tree: Array
+    },
     components: {
       IndexBranch
     }

--- a/src/components/Data/Collections/Dropdown.vue
+++ b/src/components/Data/Collections/Dropdown.vue
@@ -1,17 +1,19 @@
 <template>
-  <dropdown :id="id" :class="class">
-    <li v-if="!isRealtime"><a href="#!">Browse documents</a></li>
-    <li><a href="#!">Watch messages</a></li>
-    <li v-if="!isRealtime"><a href="#!">Summary</a></li>
-    <li><a href="#!">View profiles</a></li>
-    <li class="divider"></li>
-    <li v-if="isRealtime"><a href="#!">Persist</a></li>
-    <li v-if="!isRealtime"><a href="#!">Edit</a></li>
-    <li v-if="!isRealtime"><a href="#!">Clone</a></li>
-    <li v-if="!isRealtime"><a href="#!">Duplicate</a></li>
-    <li v-if="!isRealtime"><a href="#!">Rename</a></li>
-    <li v-if="!isRealtime"><a href="#!" class="red-text">Truncate</a></li>
-  </dropdown>
+  <span>
+    <dropdown :id="collection" :class="class">
+      <li v-if="!isRealtime"><a href="#!">Browse documents</a></li>
+      <li><a href="#!">Watch messages</a></li>
+      <li v-if="!isRealtime"><a href="#!">Summary</a></li>
+      <li><a href="#!">View profiles</a></li>
+      <li class="divider"></li>
+      <li v-if="isRealtime"><a href="#!">Persist</a></li>
+      <li v-if="!isRealtime"><a href="#!">Edit</a></li>
+      <li v-if="!isRealtime"><a href="#!">Clone</a></li>
+      <li v-if="!isRealtime"><a href="#!">Duplicate</a></li>
+      <li v-if="!isRealtime"><a href="#!">Rename</a></li>
+      <li v-if="!isRealtime"><a href="#!" class="red-text">Truncate</a></li>
+    </dropdown>
+  </span>
 </template>
 
 
@@ -20,7 +22,12 @@
 
   export default {
     name: 'CollectionDropdown',
-    props: ['id', 'isRealtime', 'class'],
+    props: {
+      index: String,
+      collection: String,
+      isRealtime: Boolean,
+      'class': String
+    },
     components: {
       Dropdown
     }

--- a/src/components/Data/Collections/Watch.vue
+++ b/src/components/Data/Collections/Watch.vue
@@ -1,14 +1,18 @@
 <template>
   <div class="wrapper">
     <headline>
-      {{$route.params.collection}} - Watch
-      <collection-dropdown class="icon-medium icon-black" :id="$route.params.index"></collection-dropdown>
+      {{collection}} - Watch
+      <collection-dropdown
+        class="icon-medium icon-black"
+        :index="index"
+        :collection="collection">
+      </collection-dropdown>
     </headline>
 
     <div class="notification-container">
       <div class="row">
         <div class="col s12">
-          <button class="btn waves-effect waves-light" @click="manageSub($route.params.index, $route.params.collection)">
+          <button class="btn waves-effect waves-light" @click="manageSub(index, collection)">
             <i :class="{'fa-play': !subscribed, 'fa-pause': subscribed}" class="fa"></i>&nbsp;{{subscribed ? 'Unsubscribe' : 'Subscribe'}}
           </button>
           <button class="btn waves-effect waves-light" @click="clear">
@@ -53,6 +57,10 @@
 
   export default {
     name: 'CollectionWatch',
+    props: {
+      index: String,
+      collection: String
+    },
     data () {
       return {
         subscribed: false,

--- a/src/components/Data/Indexes/Boxed.vue
+++ b/src/components/Data/Indexes/Boxed.vue
@@ -15,7 +15,7 @@
 
         <div class="col s1 right-align">
           <!-- actions related to the index -->
-          <index-dropdown :id="index" class="icon-small icon-black"></index-dropdown>
+          <index-dropdown :index="index" class="icon-small icon-black"></index-dropdown>
         </div>
 
 
@@ -56,7 +56,9 @@
 
   export default {
     name: 'IndexBoxed',
-    props: ['index'],
+    props: {
+      index: String
+    },
     components: {
       IndexDropdown
     }

--- a/src/components/Data/Indexes/Dropdown.vue
+++ b/src/components/Data/Indexes/Dropdown.vue
@@ -1,15 +1,17 @@
 <template>
-  <dropdown :id="id" :class="class">
-    <li><a href="#!">Browse collections</a></li>
-    <li><a href="#!">View profiles</a></li>
-    <li class="divider"></li>
-    <li><a href="#!">Edit</a></li>
-    <li><a href="#!">Clone</a></li>
-    <li><a href="#!">Duplicate</a></li>
-    <li><a href="#!">Rename</a></li>
-    <li><a href="#!" class="red-text">Truncate</a></li>
-    <li><a href="#!" class="red-text">Delete</a></li>
-  </dropdown>
+  <span>
+    <dropdown :id="index" :class="class">
+      <li><a href="#!">Browse collections</a></li>
+      <li><a href="#!">View profiles</a></li>
+      <li class="divider"></li>
+      <li><a href="#!">Edit</a></li>
+      <li><a href="#!">Clone</a></li>
+      <li><a href="#!">Duplicate</a></li>
+      <li><a href="#!">Rename</a></li>
+      <li><a href="#!" class="red-text">Truncate</a></li>
+      <li><a href="#!" class="red-text">Delete</a></li>
+    </dropdown>
+  </span>
 </template>
 
 
@@ -18,7 +20,10 @@
 
   export default {
     name: 'IndexDropdown',
-    props: ['id', 'class'],
+    props: {
+      index: String,
+      'class': String
+    },
     components: {
       Dropdown
     }

--- a/src/components/Data/Indexes/ModalCreate.vue
+++ b/src/components/Data/Indexes/ModalCreate.vue
@@ -73,7 +73,9 @@
 
   export default {
     name: 'IndexCreateModal',
-    props: ['id'],
+    props: {
+      id: String
+    },
     components: {
       Modal
     },

--- a/src/components/Data/Indexes/Summary.vue
+++ b/src/components/Data/Indexes/Summary.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="wrapper">
     <headline>
-      {{$route.params.index}} - Summary
-      <index-dropdown class="icon-medium icon-black" :id="$route.params.index"></index-dropdown>
+      {{index}} - Summary
+      <index-dropdown class="icon-medium icon-black" :index="index"></index-dropdown>
     </headline>
 
 
@@ -39,7 +39,7 @@
           <div class="col s9">
             <a class="btn waves-effect waves-light"
                href="#!"
-               v-link="{name: 'DataCreateCollection', params: {index: $route.params.index}}">
+               v-link="{name: 'DataCreateCollection', params: {index: index}}">
               <i class="fa fa-plus-circle left"></i>Create a collection
             </a>
           </div>
@@ -59,7 +59,7 @@
             <a  class="card-title" href="#">
               <div class="card-panel hoverable">
                 <div class="card-content">
-                  There is no collection in index <strong>{{$route.params.index}}</strong> yet. You may want to create a new one ?
+                  There is no collection in index <strong>{{index}}</strong> yet. You may want to create a new one ?
                 </div>
               </div>
             </a>
@@ -68,7 +68,7 @@
           <collection-boxed
               v-for="collection in collections.stored | orderBy 1"
               v-if="!filter || (filter && collection.includes(filter))"
-              :index="$route.params.index"
+              :index="index"
               :collection="collection"
               :is-realtime="false">
           </collection-boxed>
@@ -76,7 +76,7 @@
           <collection-boxed
               v-for="collection in collections.realtime | orderBy 1"
               v-if="!filter || (filter && collection.includes(filter))"
-              :index="$route.params.index"
+              :index="index"
               :collection="collection"
               :is-realtime="true">
           </collection-boxed>
@@ -121,6 +121,9 @@
 
   export default {
     name: 'IndexesSummary',
+    props: {
+      index: String
+    },
     components: {
       Headline,
       CollectionBoxed,
@@ -131,8 +134,13 @@
         filter: ''
       }
     },
+    watch: {
+      'index': function (index) {
+        this.getCollectionsFromIndex(index)
+      }
+    },
     ready () {
-      this.getCollectionsFromIndex(this.$route.params.index)
+      this.getCollectionsFromIndex(this.index)
     },
     computed: {
       hasCollection () {

--- a/src/components/Data/Layout.vue
+++ b/src/components/Data/Layout.vue
@@ -15,8 +15,8 @@
       </li>
       <li>
         <treeview
-          :index="$route.params.index"
-          :collection="$route.params.collection"
+          :index="currentIndex"
+          :collection="selectedCollection"
           :tree="indexesAndCollections">
         </treeview>
       </li>
@@ -25,14 +25,14 @@
   <section class="breadcrumb-view">
     <breadcrumb
       :route-name="$route.name"
-      :index="$route.params.index"
-      :collection="$route.params.collection">
+      :index="selectedIndex"
+      :collection="selectedCollection">
     </breadcrumb>
 
     <section class="view">
       <router-view
-        :index="$route.params.index"
-        :collection="$route.params.collection">
+        :index="selectedIndex"
+        :collection="selectedCollection">
       </router-view>
     </section>
   </section>
@@ -50,7 +50,7 @@
 <script>
   import {listIndexesAndCollections} from '../../vuex/modules/data/actions'
   import {getError} from '../../vuex/modules/common/getters'
-  import {indexesAndCollections} from '../../vuex/modules/data/getters'
+  import {indexesAndCollections, selectedIndex, selectedCollection} from '../../vuex/modules/data/getters'
   import Treeview from './Browse/Treeview'
   import Breadcrumb from './Breadcrumb'
 
@@ -68,6 +68,8 @@
         listIndexesAndCollections
       },
       getters: {
+        selectedIndex,
+        selectedCollection,
         error: getError,
         indexesAndCollections
       }

--- a/src/components/Data/Layout.vue
+++ b/src/components/Data/Layout.vue
@@ -14,7 +14,11 @@
         </nav>
       </li>
       <li>
-        <treeview :tree="indexesAndCollections"></treeview>
+        <treeview
+          :index="$route.params.index"
+          :collection="$route.params.collection"
+          :tree="indexesAndCollections">
+        </treeview>
       </li>
     </ul>
   </aside>
@@ -26,7 +30,10 @@
     </breadcrumb>
 
     <section class="view">
-      <router-view></router-view>
+      <router-view
+        :index="$route.params.index"
+        :collection="$route.params.collection">
+      </router-view>
     </section>
   </section>
 </template>

--- a/src/components/Data/Layout.vue
+++ b/src/components/Data/Layout.vue
@@ -15,7 +15,7 @@
       </li>
       <li>
         <treeview
-          :index="currentIndex"
+          :index="selectedIndex"
           :collection="selectedCollection"
           :tree="indexesAndCollections">
         </treeview>

--- a/src/vuex/modules/data/getters.js
+++ b/src/vuex/modules/data/getters.js
@@ -17,3 +17,11 @@ export const room = state => {
 export const collections = state => {
   return state.data.collections
 }
+
+export const selectedIndex = state => {
+  return state.route.params.index
+}
+
+export const selectedCollection = state => {
+  return state.route.params.collection
+}

--- a/test/unit/specs/data/browse/treeview.spec.js
+++ b/test/unit/specs/data/browse/treeview.spec.js
@@ -33,7 +33,12 @@ describe('IndexBranch component', () => {
     })
 
     const TestComponent = Vue.extend({
-      template: '<index-branch v-ref:indexbranch v-bind:index="tree"></index-branch>',
+      template: '<index-branch ' +
+                  'v-ref:indexbranch ' +
+                  'v-bind:index="index" ' +
+                  'v-bind:collection="collection" ' +
+                  'v-bind:index-tree="tree">' +
+                '</index-branch>',
       components: { IndexBranch },
       data () {
         return {
@@ -81,47 +86,39 @@ describe('IndexBranch component', () => {
   })
 
   it('should correctly determine whether an index is active', () => {
-    let indexName = 'toto'
-    let $route = {
-      params: {
-        index: indexName
-      }
-    }
+    let indexName = 'index'
+    $vm.index = indexName
+    expect($vm.isIndexActive(indexName)).to.equal(true)
 
-    expect($vm.isIndexActive($route, indexName)).to.equal(true)
+    $vm.index = 'tata'
+    expect($vm.isIndexActive(indexName)).to.equal(false)
 
-    $route.params.index = 'tata'
-    expect($vm.isIndexActive($route, indexName)).to.equal(false)
-
-    $route.params.index = indexName
-    $route.params.collection = 'titi'
-    expect($vm.isIndexActive($route, indexName)).to.equal(false)
+    $vm.collection = 'titi'
+    expect($vm.isIndexActive(indexName)).to.equal(false)
   })
 
   it('should correctly determine whether a collection is active', () => {
-    let collectionName = 'tata'
-    let $route = {
-      params: {
-        index: 'toto',
-        collection: collectionName
-      }
-    }
-    expect($vm.isCollectionActive($route, collectionName)).to.equal(true)
+    let collectionName = 'collection'
+    $vm.collection = collectionName
+    expect($vm.isCollectionActive(collectionName)).to.equal(true)
 
-    $route.params.collection = 'tutu'
-    expect($vm.isCollectionActive($route, collectionName)).to.equal(false)
+    $vm.collection = 'tutu'
+    expect($vm.isCollectionActive(collectionName)).to.equal(false)
   })
 
   it('should open when ready with active route', () => {
-    router.go('/index/collection')
+    $vm.index = 'index'
+    $vm.collection = 'collection'
     $vm.$options.ready[0].call($vm)
     expect($vm.open).to.equal(false)
 
-    router.go('/kuzzle-bo-testindex')
+    $vm.index = 'kuzzle-bo-testindex'
+    $vm.collection = ''
     $vm.$options.ready[0].call($vm)
     expect($vm.open).to.equal(true)
 
-    router.go('/kuzzle-bo-testindex/collection')
+    $vm.index = 'kuzzle-bo-testindex'
+    $vm.collection = 'collection'
     $vm.$options.ready[0].call($vm)
     expect($vm.open).to.equal(true)
   })


### PR DESCRIPTION
Remove `$route` reference in all views.
Instead, forward `index` & `collection` into `props` for all child view's

Added a watcher on `index` property into indexes browse view: when a user change selected index in the tree view, collection list is now refreshed well.

Added also ` --allow-root` for `bower install` due to building in a docker environment (which is done with `root` user)