### PR TITLE
add global loader + route loader

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,17 @@
   <head>
     <meta charset="utf-8">
     <title>kuzzle-backoffice</title>
+    <style>.app-loading{position:fixed;top:0;left:0;bottom:0;right:0;padding-top:50px;height:100%;overflow:auto;background:linear-gradient(45deg,rgba(31,77,81,1) 0,rgba(0,75,82,1) 22%,rgba(18,105,109,1) 75%,rgba(0,117,127,1) 100%)}.app-loading>div{box-sizing:border-box;font-family:Arial,sans-serif;padding:20px 40px;width:400px;text-align:center;margin:0 auto;font-weight:400;left:50%;right:50%;display:block;background-color:#fff;transition:box-shadow .25s;border-radius:2px;box-shadow:0 2px 5px 0 rgba(0,0,0,.16),0 2px 10px 0 rgba(0,0,0,.12);font-size:14px}.app-loading .loader,.app-loading .loader:after,.app-loading .loader:before{border-radius:50%;width:2.5em;height:2.5em;-webkit-animation:load7 1.8s infinite ease-in-out;animation:load7 1.8s infinite ease-in-out}.app-loading .loader{color:#00757F;font-size:2px;margin:10px auto;position:relative;text-indent:-9999em;-webkit-transform:translateZ(0);-ms-transform:translateZ(0);transform:translateZ(0);-webkit-animation-delay:-.16s;animation-delay:-.16s}.app-loading .loader:before{left:-3.5em;-webkit-animation-delay:-.32s;animation-delay:-.32s}.app-loading .loader:after{left:3.5em}.app-loading .loader:after,.app-loading .loader:before{content:'';position:absolute;top:0}@-webkit-keyframes load7{0%,100%,80%{box-shadow:0 2.5em 0 -1.3em}40%{box-shadow:0 2.5em 0 0}}@keyframes load7{0%,100%,80%{box-shadow:0 2.5em 0 -1.3em}40%{box-shadow:0 2.5em 0 0}}</style>
   </head>
   <body>
-    <app></app>
+    <app>
+      <div class="app-loading">
+        <div>
+          <span>loading kuzzle backoffice</span>
+          <div class="loader"></div>
+        </div>
+      </div>
+    </app>
     <!-- built files will be auto injected -->
   <script src="static/bower_components/ace-builds/src-noconflict/ace.js"></script>
   </body>

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -1,10 +1,30 @@
 <template>
   <main-menu></main-menu>
 
-  <main>
+  <main class="loader">
     <router-view></router-view>
   </main>
 </template>
+
+<style lang="scss" rel="stylesheet/scss" scoped>
+  .loader {
+    transition: opacity .5s ease-out;
+    opacity: 1;
+
+    &.loading {
+      opacity: 0.3;
+
+      &:before {
+        content: "loading ...";
+        position: fixed;
+        text-align: center;
+        left: 0;
+        right: 0;
+        bottom: 10px;
+      }
+    }
+  }
+</style>
 
 <script>
   import MainMenu from './Materialize/MainMenu'

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -46,6 +46,19 @@ export default function createRoutes (router) {
   })
 
   router.beforeEach(transition => {
+    Array.prototype.forEach.call(document.querySelectorAll('.loader'), element => {
+      element.classList.add('loading')
+    })
+    transition.next()
+  })
+
+  router.afterEach(transition => {
+    Array.prototype.forEach.call(document.querySelectorAll('.loader'), element => {
+      element.classList.remove('loading')
+    })
+  })
+
+  router.beforeEach(transition => {
     if (transition.to.name !== 'Signup' && !adminAlreadyExists(store.state)) {
       transition.redirect('/signup')
       return


### PR DESCRIPTION
Added UX for low latency network
- Pre loader *(in `index.html` ~ 2.3kb once builded)* which display a loader until the application is ready to start
- Smooth loader while lazy loading new routes

Steps to reproduce: 
- go to the backoffice on chrome
- open chrome web developer
- go to network tab > switch the throttling selector to "Regular 3G ..."
- refresh the backoffice
- navigate through pages

*there is a css style minified in the `index.html` file, it's because webpack doesn't compile inline styles on `npm run build`*