### PR TITLE
Use the same port for both websocket and socketio protocols 

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -85,8 +85,7 @@ module.exports = {
     new webpack.DefinePlugin({
       'process.env': {
         'BACKEND_HOST': JSON.stringify(process.env.BACKEND_HOST),
-        'BACKEND_IOPORT': JSON.stringify(process.env.BACKEND_IOPORT),
-        'BACKEND_WSPORT': JSON.stringify(process.env.BACKEND_WSPORT)
+        'BACKEND_PORT': JSON.stringify(process.env.BACKEND_PORT)
       }
     })
   ]

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "karma-sourcemap-loader": "0.3.7",
     "karma-spec-reporter": "0.0.26",
     "karma-webpack": "1.8.0",
-    "kuzzle-sdk": "3.1.1",
+    "kuzzle-sdk": "3.2.0",
     "lolex": "1.5.1",
     "materialize-css": "0.97.6",
     "mocha": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-backoffice",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A handy back-office for Kuzzle.io",
   "author": "The Kuzzle team <support@kuzzle.io>",
   "private": false,

--- a/src/components/Common/Environments/ModalCreate.vue
+++ b/src/components/Common/Environments/ModalCreate.vue
@@ -29,17 +29,8 @@
       <div class="row">
         <div class="col s12">
           <div class="input-field left-align">
-            <input id="ioport" type="number" v-model="environment.ioPort" required :class="{invalid: errors.ioPort}">
-            <label for="ioport" :class="{'active': environment.ioPort}" data-error="ioPort must be an integer between 1000 and 9999">ioPort</label>
-          </div>
-        </div>
-      </div>
-
-      <div class="row last-row">
-        <div class="col s12">
-          <div class="input-field left-align">
-            <input id="wsport" type="number" v-model="environment.wsPort" required :class="{invalid: errors.wsPort}">
-            <label for="wsport" :class="{'active': environment.wsPort}" data-error="wsPort must be an integer between 1000 and 9999">wsPort</label>
+            <input id="port" type="number" v-model="environment.port" required :class="{invalid: errors.port}">
+            <label for="port" :class="{'active': environment.port}" data-error="port must be an integer between 1000 and 9999">port</label>
           </div>
         </div>
       </div>
@@ -146,15 +137,13 @@
     data () {
       return {
         errors: {
-          wsPort: false,
-          ioPort: false,
+          port: false,
           host: false
         },
         environment: {
           name: null,
           host: null,
-          ioPort: 7512,
-          wsPort: 7513,
+          port: 7512,
           color: DEFAULT_COLOR
         },
         colors: [DEFAULT_COLOR, '#0277bd', '#8e24aa', '#689f38', '#f57c00', '#e53935', '#546e7a', '#d81b60']
@@ -163,12 +152,11 @@
     methods: {
       createEnvironments () {
         this.errors.name = (!this.environment.name)
-        this.errors.wsPort = (!this.environment.wsPort || this.environment.wsPort < 1000 || this.environment.wsPort > 9999)
-        this.errors.ioPort = (!this.environment.ioPort || this.environment.ioPort < 1000 || this.environment.ioPort > 9999)
+        this.errors.port = (!this.environment.port || this.environment.port < 1000 || this.environment.port > 9999)
         // Host is required and must be something like 'mydomain.com/toto'
         this.errors.host = (!this.environment.host || /^(http|ws):\/\//.test(this.environment.host))
 
-        if (!this.errors.name && !this.errors.wsPort && !this.errors.ioPort && !this.errors.host) {
+        if (!this.errors.name && !this.errors.port && !this.errors.host) {
           if (this.environmentId) {
             this.$store.dispatch(UPDATE_ENVIRONMENT, {
               id: this.environmentId,
@@ -176,8 +164,7 @@
                 name: this.environment.name,
                 color: this.environment.color,
                 host: this.environment.host,
-                ioPort: this.environment.ioPort,
-                wsPort: this.environment.wsPort
+                port: this.environment.port
               }
             })
           } else {
@@ -185,8 +172,7 @@
               this.environment.name,
               this.environment.color,
               this.environment.host,
-              this.environment.ioPort,
-              this.environment.wsPort)
+              this.environment.port)
           }
 
           this.close()
@@ -201,14 +187,12 @@
         if (this.environmentId && this.environments[this.environmentId]) {
           this.environment.name = this.environments[this.environmentId].name
           this.environment.host = this.environments[this.environmentId].host
-          this.environment.ioPort = this.environments[this.environmentId].ioPort
-          this.environment.wsPort = this.environments[this.environmentId].wsPort
+          this.environment.port = this.environments[this.environmentId].port
           this.environment.color = this.environments[this.environmentId].color
         } else {
           this.environment.name = null
           this.environment.host = null
-          this.environment.ioPort = 7512
-          this.environment.wsPort = 7513
+          this.environment.port = 7512
           this.environment.color = DEFAULT_COLOR
         }
       }

--- a/src/components/Error/KuzzleDisconnectedPage.vue
+++ b/src/components/Error/KuzzleDisconnectedPage.vue
@@ -39,7 +39,7 @@
     },
     mounted () {
       this.host = kuzzle.host
-      this.port = kuzzle.wsPort
+      this.port = kuzzle.port
 
       idReconnect = kuzzle.addListener('reconnected', () => {
         this.$router.push({name: 'Home'})

--- a/src/components/Error/KuzzleErrorPage.vue
+++ b/src/components/Error/KuzzleErrorPage.vue
@@ -43,7 +43,7 @@
     },
     mounted () {
       this.host = kuzzle.host
-      this.port = kuzzle.wsPort
+      this.port = kuzzle.port
 
       idReconnect = kuzzle.addListener('reconnected', () => {
         this.$router.push({name: 'Home'})

--- a/src/services/environment.js
+++ b/src/services/environment.js
@@ -11,8 +11,7 @@ const defaultEnvironment = {
   [DEFAULT]: {
     name: 'localhost',
     host: 'localhost',
-    ioPort: 7512,
-    wsPort: 7513,
+    port: 7512,
     color: DEFAULT_COLOR
   }
 }
@@ -50,12 +49,11 @@ export const loadEnvironments = () => {
  * @param  {String} The name of the environment (displayed in the list).
  * @param  {String} The HEX color code of the main header bar when connected.
  * @param  {String} The hostname.
- * @param  {int} The port number for the Socket.IO protocol.
- * @param  {int} The port number for the Websocket protocol.
+ * @param  {int} The port number.
  *
  * @return {Object} The environment object.
  */
-export const createEnvironment = (name, color, host, ioPort, wsPort) => {
+export const createEnvironment = (name, color, host, port) => {
   if (!color) {
     color = DEFAULT_COLOR
   }
@@ -64,8 +62,7 @@ export const createEnvironment = (name, color, host, ioPort, wsPort) => {
     name,
     color,
     host,
-    ioPort,
-    wsPort
+    port
   }
 
   store.dispatch(kuzzleTypes.ADD_ENVIRONMENT, {id: name, environment: newEnvironment, persist: true})

--- a/src/services/kuzzleWrapper.js
+++ b/src/services/kuzzleWrapper.js
@@ -24,13 +24,15 @@ export const waitForConnected = (timeout = 1000) => {
 }
 
 export const connectToEnvironment = (environment) => {
+  // fix default port for users that have an old environment settings in their localStorage:
+  if (environment.port === undefined) environment.port = 7512
+
   if (kuzzle.state === 'connected') {
     kuzzle.disconnect()
   }
 
   kuzzle.host = environment.host
-  kuzzle.ioPort = environment.ioPort
-  kuzzle.wsPort = environment.wsPort
+  kuzzle.port = environment.port
   kuzzle.connect()
 }
 

--- a/test/unit/specs/components/common/environments/modalCreate.spec.js
+++ b/test/unit/specs/components/common/environments/modalCreate.spec.js
@@ -14,8 +14,7 @@
 //     myEnv: {
 //       name: 'myEnv',
 //       host: 'myHost',
-//       ioPort: 8888,
-//       wsPort: 9999,
+//       port: 8888,
 //       color: DEFAULT_COLOR
 //     }
 //   }
@@ -59,8 +58,7 @@
 //         Vue.nextTick(() => {
 //           expect($vm.environment.name).to.be.equal(null)
 //           expect($vm.environment.host).to.be.equal(null)
-//           expect($vm.environment.ioPort).to.be.equal(7512)
-//           expect($vm.environment.wsPort).to.be.equal(7513)
+//           expect($vm.environment.port).to.be.equal(7512)
 //           expect($vm.environment.color).to.be.equal(DEFAULT_COLOR)
 //           done()
 //         })
@@ -81,8 +79,7 @@
 //     describe('createEnvironments', () => {
 //       it('should set error and do nothing on name error', () => {
 //         $vm.environment.name = null
-//         $vm.environment.wsPort = 7513
-//         $vm.environment.ioPort = 7512
+//         $vm.environment.port = 7512
 //         $vm.environment.host = 'localhost'
 //
 //         updateEnvironment.reset()
@@ -98,8 +95,7 @@
 //
 //       it('should set error and do nothing on host error', () => {
 //         $vm.environment.name = 'localhost'
-//         $vm.environment.wsPort = 7513
-//         $vm.environment.ioPort = 7512
+//         $vm.environment.port = 7512
 //         $vm.environment.host = 'http://toto'
 //
 //         updateEnvironment.reset()
@@ -125,10 +121,10 @@
 //         expect($vm.$broadcast.callCount).to.be.equal(0)
 //       })
 //
-//       it('should set error and do nothing on wsPort error', () => {
+//
+//       it('should set error and do nothing on port error', () => {
 //         $vm.environment.name = 'localhost'
-//         $vm.environment.wsPort = -7513
-//         $vm.environment.ioPort = 7512
+//         $vm.environment.port = -7512
 //         $vm.environment.host = 'localhost'
 //
 //         updateEnvironment.reset()
@@ -136,24 +132,7 @@
 //         $vm.$broadcast.reset()
 //
 //         $vm.createEnvironments()
-//         expect($vm.errors.wsPort).to.be.equal(true)
-//         expect(updateEnvironment.callCount).to.be.equal(0)
-//         expect(createEnvironment.callCount).to.be.equal(0)
-//         expect($vm.$broadcast.callCount).to.be.equal(0)
-//       })
-//
-//       it('should set error and do nothing on ioPort error', () => {
-//         $vm.environment.name = 'localhost'
-//         $vm.environment.wsPort = 7513
-//         $vm.environment.ioPort = -7512
-//         $vm.environment.host = 'localhost'
-//
-//         updateEnvironment.reset()
-//         createEnvironment.reset()
-//         $vm.$broadcast.reset()
-//
-//         $vm.createEnvironments()
-//         expect($vm.errors.ioPort).to.be.equal(true)
+//         expect($vm.errors.port).to.be.equal(true)
 //         expect(updateEnvironment.callCount).to.be.equal(0)
 //         expect(createEnvironment.callCount).to.be.equal(0)
 //         expect($vm.$broadcast.callCount).to.be.equal(0)
@@ -161,8 +140,7 @@
 //
 //       it('should update environment and close modal', () => {
 //         $vm.environment.name = 'localhost'
-//         $vm.environment.wsPort = 7513
-//         $vm.environment.ioPort = 7512
+//         $vm.environment.port = 7512
 //         $vm.environment.host = 'localhost'
 //
 //         $vm.environmentId = 10
@@ -179,8 +157,7 @@
 //
 //       it('should create environment and close modal', () => {
 //         $vm.environment.name = 'localhost'
-//         $vm.environment.wsPort = 7513
-//         $vm.environment.ioPort = 7512
+//         $vm.environment.port = 7512
 //         $vm.environment.host = 'localhost'
 //
 //         $vm.environmentId = null

--- a/test/unit/specs/components/error/kuzzleDisconnectedPage.spec.js
+++ b/test/unit/specs/components/error/kuzzleDisconnectedPage.spec.js
@@ -15,7 +15,7 @@ describe('KuzzleDisconnectedPage component', () => {
     KuzzleDisconnectedPage = KuzzleDisconnectedPageInjector({
       '../../services/kuzzle': {
         host: 'toto',
-        wsPort: 8888,
+        port: 8888,
         addListener: (event, cb) => {
           if (testedEvent === event) {
             cb()

--- a/test/unit/specs/services/environment.spec.js
+++ b/test/unit/specs/services/environment.spec.js
@@ -157,8 +157,7 @@
 //         'environment',
 //         null,
 //         'localhost',
-//         7512,
-//         7513
+//         7512
 //       )
 //       expect(resultEnv.color).to.equals(environment.DEFAULT_COLOR)
 //     })
@@ -191,17 +190,15 @@
 //       const host = 'localhost'
 //       const color = '#000'
 //       const name = 'toto'
-//       const ioPort = 7582
-//       const wsPort = 7545
+//       const port = 7582
 //
 //       const updatedEnv = envService
-//         .updateEnvironment('valid', name, color, host, ioPort, wsPort)
+//         .updateEnvironment('valid', name, color, host, port)
 //
 //       expect(updatedEnv.host).to.equals(host)
 //       expect(updatedEnv.color).to.equals(color)
 //       expect(updatedEnv.name).to.equals(name)
-//       expect(updatedEnv.ioPort).to.equals(ioPort)
-//       expect(updatedEnv.wsPort).to.equals(wsPort)
+//       expect(updatedEnv.port).to.equals(port)
 //       expect(updatedEnv.user).to.equals(dummyEnvironments['valid'].user)
 //     })
 //   })

--- a/test/unit/specs/services/kuzzleWrapper.spec.js
+++ b/test/unit/specs/services/kuzzleWrapper.spec.js
@@ -107,7 +107,7 @@ describe('Kuzzle wrapper service', () => {
     })
 
     it('should disconnect and reconnect kuzzle after setting the environment params', () => {
-      kuzzleWrapper.connectToEnvironment({host: 'toto.toto', ioPort: 7512, wsPort: 7513})
+      kuzzleWrapper.connectToEnvironment({host: 'toto.toto', port: 7512})
 
       expect(disconnectMock.called).to.equals(true)
       expect(connectMock.called).to.equals(true)
@@ -222,7 +222,7 @@ describe('Kuzzle wrapper service', () => {
       kuzzleWrapper = kuzzleWrapperInjector({
         './kuzzle': {
           host: 'toto',
-          wsPort: 8888,
+          port: 8888,
           state: 'connecting',
           addListener (event, cb) {
             cb()

--- a/test/unit/specs/vuex/common/kuzzle/mutations.spec.js
+++ b/test/unit/specs/vuex/common/kuzzle/mutations.spec.js
@@ -54,7 +54,7 @@ describe('kuzzle environments mutations test', () => {
     it('should create a new environment', () => {
       let newEnvironment = {
         host: 'localhost',
-        wsPort: 7513
+        port: 7512
       }
       ADD_ENVIRONMENT(state, {id: 'new', environment: newEnvironment})
       expect(state.environments.new).to.deep.equals(newEnvironment)
@@ -71,7 +71,7 @@ describe('kuzzle environments mutations test', () => {
     it('should update an existing environment', () => {
       let newEnvironment = {
         host: 'localhost',
-        wsPort: 7513
+        port: 7512
       }
       UPDATE_ENVIRONMENT(state, {id: 'valid', environment: newEnvironment})
       expect(state.environments.valid).to.deep.equals(newEnvironment)


### PR DESCRIPTION
Following 
https://github.com/kuzzleio/kuzzle-proxy/pull/48
https://github.com/kuzzleio/sdk-javascript/pull/180

Use now the same port (`7512`) for both websocket and socketio protocols 

TODO: update the JS SDK version in `package.json` after the deployment of https://github.com/kuzzleio/sdk-javascript/pull/180