### PR TITLE
Allows ssl connections to Kuzzle

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "karma-sourcemap-loader": "0.3.7",
     "karma-spec-reporter": "0.0.26",
     "karma-webpack": "1.8.0",
-    "kuzzle-sdk": "3.2.0",
+    "kuzzle-sdk": "3.4.1",
     "lolex": "1.5.1",
     "materialize-css": "0.97.6",
     "mocha": "3.0.2",

--- a/src/components/Common/Environments/ModalCreate.vue
+++ b/src/components/Common/Environments/ModalCreate.vue
@@ -27,11 +27,22 @@
       </div>
 
       <div class="row">
-        <div class="col s12">
+        <div class="col s6">
           <div class="input-field left-align">
             <input id="port" type="number" v-model="environment.port" required :class="{invalid: errors.port}">
-            <label for="port" :class="{'active': environment.port}" data-error="port number must be an integer">port</label>
+            <label for="port" :class="{'active': environment.port}" data-error="port number must be an integer">Port</label>
           </div>
+        </div>
+        <div class="col s6">
+          <div class="input-field left-align">
+            <input id="ssl" type="checkbox" v-model="environment.ssl">
+            <label for="ssl">use SSL</label>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col s12">
         </div>
       </div>
 
@@ -84,6 +95,9 @@
         background-color: #EEE;
       }
     }
+  }
+  .row {
+    margin-bottom: 5px;
   }
   .last-row {
     margin-bottom: 5px;
@@ -164,7 +178,8 @@
                 name: this.environment.name,
                 color: this.environment.color,
                 host: this.environment.host,
-                port: this.environment.port
+                port: this.environment.port,
+                ssl: this.environment.ssl
               }
             })
           } else {
@@ -172,7 +187,8 @@
               this.environment.name,
               this.environment.color,
               this.environment.host,
-              this.environment.port)
+              this.environment.port,
+              this.environment.ssl)
           }
 
           this.close()
@@ -189,11 +205,13 @@
           this.environment.host = this.environments[this.environmentId].host
           this.environment.port = this.environments[this.environmentId].port
           this.environment.color = this.environments[this.environmentId].color
+          this.environment.ssl = this.environments[this.environmentId].ssl
         } else {
           this.environment.name = null
           this.environment.host = null
           this.environment.port = 7512
           this.environment.color = DEFAULT_COLOR
+          this.environment.ssl = false
         }
       }
     }

--- a/src/components/Data/Documents/Common/CreateOrUpdate.vue
+++ b/src/components/Data/Documents/Common/CreateOrUpdate.vue
@@ -42,7 +42,7 @@
           <div class="col s7 m8 l9" v-if="error">
             <div class="card error red-color">
               <i class="fa fa-times dismiss-error" @click="dismissError()"></i>
-              <p v-html="error">
+              <p v-html="error"></p>
             </div>
           </div>
         </div>

--- a/src/services/environment.js
+++ b/src/services/environment.js
@@ -12,6 +12,7 @@ const defaultEnvironment = {
     name: 'localhost',
     host: 'localhost',
     port: 7512,
+    ssl: false,
     color: DEFAULT_COLOR
   }
 }
@@ -50,10 +51,11 @@ export const loadEnvironments = () => {
  * @param  {String} The HEX color code of the main header bar when connected.
  * @param  {String} The hostname.
  * @param  {int} The port number.
+ * @param  {boolean} ssl mode
  *
  * @return {Object} The environment object.
  */
-export const createEnvironment = (name, color, host, port) => {
+export const createEnvironment = (name, color, host, port, ssl) => {
   if (!color) {
     color = DEFAULT_COLOR
   }
@@ -62,7 +64,8 @@ export const createEnvironment = (name, color, host, port) => {
     name,
     color,
     host,
-    port
+    port,
+    ssl
   }
 
   store.dispatch(kuzzleTypes.ADD_ENVIRONMENT, {id: name, environment: newEnvironment, persist: true})

--- a/src/services/kuzzleWrapper.js
+++ b/src/services/kuzzleWrapper.js
@@ -26,6 +26,7 @@ export const waitForConnected = (timeout = 1000) => {
 export const connectToEnvironment = (environment) => {
   // fix default port for users that have an old environment settings in their localStorage:
   if (environment.port === undefined) environment.port = 7512
+  if (typeof environment.ssl !== 'boolean') environment.ssl = false
 
   if (kuzzle.state === 'connected') {
     kuzzle.disconnect()
@@ -33,6 +34,7 @@ export const connectToEnvironment = (environment) => {
 
   kuzzle.host = environment.host
   kuzzle.port = environment.port
+  kuzzle.sslConnection = environment.ssl
   kuzzle.connect()
 }
 


### PR DESCRIPTION
# Description

Fixes #154
Allows connecting to Kuzzle via SSL.

New form preview:

![selection_019](https://cloud.githubusercontent.com/assets/6680551/23410075/4233b5fc-fdce-11e6-83e4-e2ddb10675b2.png)
