### PR TITLE
Error in user list when user with empty body

### DIFF
--- a/src/components/Security/Users/UserItem.vue
+++ b/src/components/Security/Users/UserItem.vue
@@ -88,6 +88,10 @@ export default {
   },
   computed: {
     profileList () {
+      if (!this.document.content.profileIds) {
+        return []
+      }
+
       return this.document.content.profileIds.filter((item, idx) => {
         return idx < MAX_PROFILES
       })


### PR DESCRIPTION
When a user is created via Elasticsearch with an empty body, the user list throw an error about profileIds.