### PR TITLE
Do not mangle "Content" and "Meta" classes

### DIFF
--- a/build/webpack.prod.conf.js
+++ b/build/webpack.prod.conf.js
@@ -35,7 +35,10 @@ var webpackConfig = merge(baseWebpackConfig, {
       compress: {
         warnings: false
       },
-      sourceMap: true
+      sourceMap: true,
+      mangle: {
+        except: ['Content', 'Meta']
+      }
     }),
     // extract css into its own file
     new ExtractTextPlugin({


### PR DESCRIPTION
As "Content" and "Meta" classes are used to display the object property name in json-formatter we shouldn't uglify them.