### PR TITLE
Dropdown now escape the space character

### DIFF
--- a/src/components/Materialize/Dropdown.vue
+++ b/src/components/Materialize/Dropdown.vue
@@ -54,7 +54,7 @@
 
         let parsed = this.id
 
-        return parsed.replace(/[!"#$%&'()*_+,./:;<=>?@[\]^`{|}~]/g, '\\$&')
+        return parsed.replace(/[!"#$%&'()*_+,./:;<=>?@[\]^`{|}~ ]/g, '\\$&')
       }
     },
     mounted () {


### PR DESCRIPTION
Dropdown now escape the space character of a collection.

fix #285 