### PR TITLE
Do not mangle 'Credentials' object

### DIFF
--- a/build/webpack.prod.conf.js
+++ b/build/webpack.prod.conf.js
@@ -37,7 +37,7 @@ var webpackConfig = merge(baseWebpackConfig, {
       },
       sourceMap: true,
       mangle: {
-        except: ['Content', 'Meta']
+        except: ['Content', 'Meta', 'Credentials']
       }
     }),
     // extract css into its own file


### PR DESCRIPTION
Do not mangle the 'Credentials' object
fix #289 