### PR TITLE
Fix stylesheet to avoid blurry buttons

### DIFF
--- a/src/assets/search.scss
+++ b/src/assets/search.scss
@@ -1,7 +1,8 @@
 .search-filter {
   .filters {
     .actions-quicksearch {
-      transform: translateY(25%);
+      height: 48px;
+      line-height: 48px;
     }
     .search-bar {
       position: relative;

--- a/src/components/Common/Filters/QuickFilter.vue
+++ b/src/components/Common/Filters/QuickFilter.vue
@@ -9,7 +9,7 @@
           <a v-else href="#" class="fluid-hover" @click.prevent="displayComplexSearch">Less query options</a>
         </div>
       </div>
-      <div class="col s3 actions-quicksearch">
+      <div class="col s5 actions-quicksearch">
         <button type="submit" class="btn btn-small waves-effect waves-light" @click.prevent="quickSearch">Search</button>
         <button class="btn-flat btn-small waves-effect waves-light" @click="resetQuickSearch">reset</button>
       </div>


### PR DESCRIPTION
Fixes #328 

Mentioned issue was due to a `transform: translateY(25%)` CSS rule introduced to vertically center Search and Reset buttons, right next to a search input.
The problem is that these transform rules exclude the classic rendering, handing it (probably) to the GPU which (surprisingly) introduces subsampling and excessive anti-aliasing (on certain screens, at certain values -- 26% was _neat_). We are not sure of that, but changing the `translate` to a `line-height` rule solved the issue.

CSS is hackland. It's useless to try to understand.