### PR TITLE
Fixed profile creation

### DIFF
--- a/src/components/Security/Profiles/Create.vue
+++ b/src/components/Security/Profiles/Create.vue
@@ -49,7 +49,7 @@
 
         kuzzle
           .security
-          .createProfilePromise(this.id, profile, {replaceIfExist: true})
+          .createProfilePromise(this.id, profile.policies, {replaceIfExist: true})
           .then(() => {
             setTimeout(() => { // we can't perform refresh index on %kuzzle
               this.$router.push({name: 'SecurityProfilesList'})


### PR DESCRIPTION
When creating a Profile, the component [sent the data as an `Object`](https://github.com/kuzzleio/kuzzle-backoffice/blob/2.x/src/components/Data/Documents/Common/CreateOrUpdate.vue#L133), which made Kuzzle complain about the type of the `policies` attribute of the `input.body` of the Request.

![selection_070](https://user-images.githubusercontent.com/5023426/29884103-a0bbc924-8db2-11e7-928f-99bc0073436c.png)

