### PR TITLE
Fix collection dropdown not activating

### DIFF
--- a/src/components/Materialize/Dropdown.vue
+++ b/src/components/Materialize/Dropdown.vue
@@ -55,7 +55,7 @@
 
         let parsed = this.id + this._uid
 
-        return parsed.replace(/[!"#$%&'()*_+,./:;<=>?@[\]^`{|}~ ]/g, '\\$&')
+        return parsed.replace(/[!"#$%&'()*+,./:;<=>?@[\]^`{|}~ ]/g, '\\$&')
       }
     },
     mounted () {


### PR DESCRIPTION
Issue happened when a collection was named with one or more underscores