### PR TITLE
Show a message instead of a form if the target collection doesn't have a mapping

### DIFF
--- a/src/components/Common/JsonForm/JsonForm.vue
+++ b/src/components/Common/JsonForm/JsonForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div  v-if="Object.keys(schema).length">
     <div class="json-form" v-for="(content, name) in schema">
       <!-- For nested objects -->
       <fieldset v-if="isNested(content)">
@@ -15,6 +15,9 @@
       </div>
     </div>
   </div>
+  <p v-else>
+    No collection mapping detected. You need to configure your collection to enable this form.
+  </p>
 </template>
 
 <script>


### PR DESCRIPTION
Adding message when create a document if collection has no mapping : 
"No collection mapping detected. You need to configure your collection to enable this form."