### PR TITLE
Improve header wording in create collection

### DIFF
--- a/src/components/Data/Collections/Create.vue
+++ b/src/components/Data/Collections/Create.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="hasRights">
     <create-or-update
-      headline="Create collection"
+      headline="Create a new collection in"
       @collection-create::create="create"
       @collection-create::reset-error="error = ''"
       @document-create::error="setError"

--- a/src/components/Data/Collections/CreateOrUpdate.vue
+++ b/src/components/Data/Collections/CreateOrUpdate.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="wrapper collection-edit">
     <headline>
-      {{index}} - {{headline}}
+      {{headline}} {{index}}
     </headline>
 
     <stepper


### PR DESCRIPTION
Change wording to : "Create a new collection in `index`"