### PR TITLE
Fix bug when "auto-generate" kuid is checked when creating a user

### DIFF
--- a/src/components/Security/Users/Steps/StepsContent.vue
+++ b/src/components/Security/Users/Steps/StepsContent.vue
@@ -77,6 +77,7 @@
       },
       setAutoGenerateKuid (value) {
         this.autoGenerateKuid = value
+        this.updateUser()
       },
       setCustomKuid (value) {
         this.kuid = value


### PR DESCRIPTION
Missing call `updateUser` when "auto-generate" checkbox is checked 