### PR TITLE
Fix #362 dispatch LIST_INDEXES_AND_COLLECTION when prepare session

### DIFF
--- a/src/vuex/modules/auth/actions.js
+++ b/src/vuex/modules/auth/actions.js
@@ -2,6 +2,7 @@ import kuzzle from '../../../services/kuzzle'
 import SessionUser from '../../../models/SessionUser'
 import * as types from './mutation-types'
 import * as kuzzleTypes from '../common/kuzzle/mutation-types'
+import { LIST_INDEXES_AND_COLLECTION } from '../index/mutation-types'
 import Promise from 'bluebird'
 
 export default {
@@ -22,6 +23,7 @@ export default {
   [types.PREPARE_SESSION] ({commit, dispatch}, token) {
     const sessionUser = SessionUser()
     dispatch(kuzzleTypes.UPDATE_TOKEN_CURRENT_ENVIRONMENT, token)
+    dispatch(LIST_INDEXES_AND_COLLECTION)
     return kuzzle
       .whoAmIPromise()
       .then(user => {


### PR DESCRIPTION
## What does this PR do ?
Dispatch LIST_INDEXES_AND_COLLECTION after login when PREPARE_SESSION is called.

### How should this be manually tested?
- Go to admin console in private navigation
- Create environment
- Login
Now you can see all indexes and collections, no need to refresh.