### PR TITLE
main menu: Added Console Admin current version

### DIFF
--- a/src/components/Common/MainMenu.vue
+++ b/src/components/Common/MainMenu.vue
@@ -5,7 +5,7 @@
         <ul>
           <li class="logo">
             <div class="logo-container">
-              <div class="version-container right-align" :style="{color: versionColor}">{{adminConsoleVersion}}3</div>
+              <div class="version-container right-align" :style="{color: versionColor}">{{adminConsoleVersion}}</div>
               <div>
                 <a href="#" class="">
                   <img src="../../assets/logo-white.svg" alt="Kuzzle.io" />

--- a/src/components/Common/MainMenu.vue
+++ b/src/components/Common/MainMenu.vue
@@ -4,9 +4,14 @@
       <nav :style="{backgroundColor: currentEnvironmentColor}" id="mainnav">
         <ul>
           <li class="logo">
-            <a href="#" class="">
-              <img src="../../assets/logo-white.svg" alt="Kuzzle.io" />
-            </a>
+            <div class="logo-container">
+              <div class="version-container right-align" :style="{color: versionColor}">{{adminConsoleVersion}}3</div>
+              <div>
+                <a href="#" class="">
+                  <img src="../../assets/logo-white.svg" alt="Kuzzle.io" />
+                </a>
+              </div>
+            </div>
           </li>
           <router-link tag="li" class="nav" :to="{name: 'Data'}" active-class="active">
             <a>Data</a>
@@ -53,6 +58,11 @@
 
         return this.$store.getters.currentEnvironment.color
       },
+
+      versionColor () {
+        return shadeColor2(this.currentEnvironmentColor, 0.5)
+      },
+
       currentUserName () {
         if (this.$store.state.auth.user) {
           if (this.$store.state.auth.user.params && this.$store.state.auth.user.params.name) {
@@ -60,8 +70,13 @@
           }
           return this.$store.state.auth.user.id
         }
+      },
+
+      adminConsoleVersion () {
+        return require('../../../package.json').version
       }
     },
+
     methods: {
       doLogout () {
         return this.$store.dispatch(DO_LOGOUT)
@@ -78,6 +93,19 @@
       }
     }
   }
+  
+  function shadeColor2 (color, percent) {
+    // https://stackoverflow.com/questions/41173998/is-it-possible-to-use-the-computed-properties-to-compute-another-properties-in-v
+    var f, t, p, R, G, B
+    f = parseInt(color.slice(1), 16)
+    t = percent < 0 ? 0 : 255
+    p = percent < 0 ? percent * -1 : percent
+    R = f >> 16
+    G = f >> 8 & 0x00FF
+    B = f & 0x0000FF
+    return '#' + (0x1000000 + (Math.round((t - R) * p) + R) * 0x10000 + (Math.round((t - G) * p) + G) * 0x100 + (Math.round((t - B) * p) + B)).toString(16).slice(1)
+  }
+
 </script>
 
 <style rel="stylesheet/scss" lang="scss" scoped>
@@ -110,6 +138,21 @@ nav {
   height: 50px;
 }
 
+.logo-container {
+  position: relative;
+}
+
+.version-container {
+  position: absolute;
+  top:12px;
+  left: 0;
+  color: white;
+  width: 100%;
+  height: 100%;
+  padding-right: 5px;
+  z-index: -1;
+  font-size: 0.8em; 
+}
 .logo img {
   height: 50px;
   padding: 4px 50px 6px 39px;


### PR DESCRIPTION


<!--
  IMPORTANT
  Don't forget to add the corresponding "changelog:xxx" label to your PR.
  This is part of our release process in order to generate the change log.
-->


## What does this PR do ?

Adds current Kuzzle Admin Console version next to Kuzzle logo
in the top menu bar

### How should this be manually tested?
  - Step 1: Open Kuzzle Admin Console
  - Step 2: Look at the nice Kuzzle logo at to top left of the window
  - Step 3: Now look at the right of the log
 - Step 4: tada, here it is! Or at least should be...

### Screenshots (if appropriate)
In case you don't believe:
![image](https://user-images.githubusercontent.com/31733541/42804949-b64c7690-89aa-11e8-9d62-f8c5b2e074c3.png)

And it works with any color:
![image](https://user-images.githubusercontent.com/31733541/42804977-d6f65032-89aa-11e8-8c5d-04d34635adfa.png)
